### PR TITLE
FIX: added pypdf2 dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - xlsxwriter
   - xlutils
   - pyedflib
+  - pypdf2
   - pip:
     - dash
     - kaleido


### PR DESCRIPTION
Needed by pdfmerger. See also the PR for the ulstools